### PR TITLE
feria 2 post trinitatis

### DIFF
--- a/Conventus/inbox/ant-diligamtedomine.gabc
+++ b/Conventus/inbox/ant-diligamtedomine.gabc
@@ -1,0 +1,6 @@
+%annotation: 1. Ant. II D;
+
+%%
+(c4)Dí(f)li(g)gam(gh) te,(f) <v>\greheightstar</v>() Dó(g)mi(fe)ne,(d) (,) 
+vir(f)tus(g) me(g)a.(f) (::)
+

--- a/Conventus/inbox/ant-domineinvirtutetua.gabc
+++ b/Conventus/inbox/ant-domineinvirtutetua.gabc
@@ -1,0 +1,4 @@
+
+%%
+(c4)Dó(f)mi(fg)ne,(g) <v>\greheightstar</v>() in(g) vir(g)tú(gh)te(g) tu(g)a(f) (,) læ(h)tá(hjh)bi(i)tur(h) rex.(g) (::)
+

--- a/Conventus/inbox/ant-dominusdecoeloprospexit.gabc
+++ b/Conventus/inbox/ant-dominusdecoeloprospexit.gabc
@@ -1,0 +1,3 @@
+
+%%
+(f3)Dó(h)mi(g)nus(h) de(f) cæ(g)lo(f) pro(e)spé(g)xit(f) <v>\greheightstar</v>(;) su(f)per(e) fí(f)li(h)os(g) hó(e)mi(g)num.(f) (::)

--- a/Conventus/inbox/ant-exaltabote-sineal.gabc
+++ b/Conventus/inbox/ant-exaltabote-sineal.gabc
@@ -1,0 +1,6 @@
+nabc-lines:1;
+nabc-source:https://www.e-codices.unifr.ch/fr/csg/0391/68;
+%%
+(c4)E(g|vi)xal(g|vi)tá(g|vi)bo(g|vi) te,(h|vi) Dó(g|ta)mi(h|vi)ne,(g|vi) <v>\greheightstar</v>(,) 
+quó(f|ta)ni(g|vi)am(h|vi) su(j|vi)sce(h|vi)pí(i|ta)sti(h|vi) me.(g) (::)
+

--- a/Conventus/inbox/ant-exaudiattedominus.gabc
+++ b/Conventus/inbox/ant-exaudiattedominus.gabc
@@ -1,0 +1,6 @@
+nabc-lines:1;
+nabc-source:https://www.e-codices.unifr.ch/fr/csg/0390/100;
+%%
+(c4)Ex(h|vi-)áu(g|vi)di(f|ta)at(g|vi) te(h|vi) Dó(j|vijg)mi(k|vihh)nus(j|vihg) <v>\greheightstar</v>(,) 
+in(j|vihg) di(j|vihg)e(j|vihg) tri(i|vi)bu(h|ta)la(jh|/cl-)ti(i|vi)ó(g|ta)nis.(g|ta) (::)
+

--- a/Conventus/inbox/ant-inclinadomine.gabc
+++ b/Conventus/inbox/ant-inclinadomine.gabc
@@ -1,0 +1,8 @@
+%annotation: 1. Ant. II D;
+nabc-lines:1;
+source:https://www.e-codices.unifr.ch/fr/csg/0390/99;
+%%
+(c3)In(ig~|cl~)clí(i|vi)na,(j|vi) Dó(i|vi)mi(hi|pe)ne,(i|vi-) <v>\greheightstar</v>(,) 
+au(i|vi)rem(g|ta) tu(h|vi)am(g|vi) mi(e|ta)hi,(e|ta) (;) 
+et(h|vi-) ex(h|peS)áu(fh|pes)di(gf|/cl-) ver(ef|peS)ba(gf|/cl-) me(e|ta)a.(e|ta) (::)
+

--- a/Conventus/inbox/ant-quioperaturiustitiam.gabc
+++ b/Conventus/inbox/ant-quioperaturiustitiam.gabc
@@ -1,0 +1,6 @@
+annotation: 2. Ant. IV E;
+
+%%
+(c4)Qui(f) o(fe)pe(d)rá(f)tur(e) iu(f)stí(gh)ti(h)am(g) <v>\greheightstar</v>(,) 
+re(g)qui(f)é(fe)scet(d) in(f) mon(f)te(f) san(fe~)cto(f) tu(g)o,(d) Dó(g)mi(fe)ne.(e) (::)
+

--- a/Conventus/inbox/ant-retribuetmihidominus.gabc
+++ b/Conventus/inbox/ant-retribuetmihidominus.gabc
@@ -1,0 +1,5 @@
+%annotation: 1. Ant. II D;
+
+%%
+(c4)Re(f)trí(g)bu(f)et(e) mi(f)hi(dc) Dó(d)mi(f)nus(e) <v>\greheightstar</v>(;) 
+se(e)cún(g)dum(gh) iu(h)stí(gf)ti(g)am(gf~) me(e)am.(e) (::)

--- a/Conventus/inbox/ant-vivitdominus.gabc
+++ b/Conventus/inbox/ant-vivitdominus.gabc
@@ -1,0 +1,6 @@
+nabc-lines:1;
+nabc-source:https://www.e-codices.unifr.ch/fr/csg/0390/100;
+%%
+(c3)Vi(g|vi)vit(h|vi) Dó(i|vi)mi(j|vi)nus(i|ta) <v>\greheightstar</v>(,) 
+et(ih|/cl-) be(f|ta)ne(h|vi)dí(gf|/cl-)ctus(e|ta) (,) 
+De(f|vi)us(e|vi) sa(d|ta)lú(ef|pe)tis(f|vi) me(e|ta)æ.(e|ta) (::)

--- a/Conventus/inbox/resp-deusomniumexauditorest-sinedox.gabc
+++ b/Conventus/inbox/resp-deusomniumexauditorest-sinedox.gabc
@@ -1,0 +1,25 @@
+name:Deus omnium exauditor est;
+office-part:Responsorium;
+mode:1;
+source:http://gregofacsimil.free.fr/01-Restitution/Repons/Repons-en-pdf/75-De-Libro-Regum/01-Deus-omnium-exauditor.pdf;
+transcriber:Marek Klein;
+commentary:Ps 151 (Apocr) \Vbar 1Rg 17,37; H395;
+cantusindex:006430;
+nabc-lines:1;
+nabc-source:https://www.e-codices.unifr.ch/fr/csg/0391/201;
+%%
+(c4)De(d!ewfd|ql!clppu1)us(d|ta) óm(de>|pe>)ni(d|ta)um(d|ta) e(d!ewf|qlppt1)xau(dc~|cl~)dí(d|vi)tor(d|vi) est:(-df|pe-|fv|vi-) (;)
+i(c|ta)pse(d|vi) mi(ixedhiv|/////povihj)sit(h|ta) An(h>|vi>)ge(gh|pe)lum(gfg|//po-1) su(ixivHG|//////ci-|hi|peS)um(h|ta) (;)
+et(f!gwhg~|qi>ppt1) tu(h|vi)lit(g>|vi>) me(fgFE|toS2sut1|fvED|//ci-|ed|/cl-) (`)
+de(d|talsc3) ó(f|vi)vi(d|ta)bus(fvv|bv-) pa(fg|peS)tris(gf|/cl-|/fd|/cl-|/fgf|//to-1|gvFE|//visut2) me(d!ewfef|ql!poppt1)i:(ed|/cl-) (:)
+<v>\greheightstar</v>()
+Et(d|ta) un(fog|pq-)xit(gh|peS) me(ixhf|////cllsc2|/hig|//to-1|/fss|/ds-|ded|//to) (`)
+un(dsfsfs>|tsM)cti(d|ta)ó(d|ta)ne(dcdCA|posu1suu1lsc3) mi(a|ta)se(c|vi)ri(d|vi)cór(d|vi-|fvEC|//cihilsc2)di(fvv|bv-)æ(ge/foe|//cl!pi) su(de!fvEDe|vi-hhpp2su2/vi)æ.(ed|/cl-) (::)
+
+<sp>V/</sp>.
+Dó(h|ta)mi(h|ta)nus,(hg|/cl|/hg|/cl|/go1f|pilsm2) qui(g|vi) e(g|vi)rí(gh|pe)pu(g|ta)it(g|ta) me(g|ta)
+de(g|ta) o(hf|/cl)re(gh|pe) le(gh|pe)ó(ixh|////ta|/iio1h|/pr)nis(h|ta) (;)
+et(hf~|cl~) de(gh|pe) ma(h|ta)nu(h|ta) bé(ixhi|////pe)sti(h|ta)æ(h|ta)
+li(hg/hg|//pf)be(hf|/cl)rá(ixf!gwhg|////ql!clppt1|/hih|//to)vit(hvGFE|///vi-su1sut2|fwghv|qlvihj) me.(gf|/cl-) (::)
+
+<v>\greheightstar</v>() Et.(d|ta) (::)

--- a/Conventus/inbox/resp-dominusquieripuitme-cumdox.gabc
+++ b/Conventus/inbox/resp-dominusquieripuitme-cumdox.gabc
@@ -1,0 +1,35 @@
+name:Dominus qui eripuit me;
+office-part:Responsorium;
+mode:8;
+transcriber:Marek Klein;
+commentary:1Sam 17, 37 \Vbar Ps 45, 6 ; Ps 46, 5; H395;
+cantusindex:006430;
+nabc-lines:1;
+nabc-source:http://www.e-codices.unifr.ch/fr/csg/0391/201;
+ntranscriber:Marek Klein;
+%%
+(c4)Dó(fgh|ta/pe)mi(g|ta)nus,(g|vi) qui(f|ta) e(-ghg|/to)rí(h|vi)pu(g|ta)it(gfg|//po) me(d|ta)
+de(g|vi) o(hggofgv|//cl!pilsc2/vi)re(gf|/cl-) le(fh!iwj|``qlhjppt2|kvJIH|////vi-hhsut3|iwjIH|ql-hhsu2)ó(g!hwihi|ql!poppt1)nis,(hg|/cl-) (;)
+et(f|ta) de(gh|pe) ma(hggo1e|//cl!pi)nu(g|vi) bé(f!goh|sa)sti(fe|/cl)æ(dec|//to|/d!ewfe|ql!clppt1|fvED|//ci-) (,)
+li(fe|/cl)be(fg|pe)rá(g|ta)vit(g!hwihi|ql!poppt1) me,(hg|/cl-) (;)
+<v>\greheightstar</v>()
+I(fh!iwj|````qlhjppt2|jok|///pq-hh)pse(g|ta) me(ge|cllsc2) e(g|vi)rí(f!goh|sa)pi(fe|/cl)et(dec|//to|/d!ewfe|ql!clppt1|fvED|//ci-) (,)
+de(dc|/cl) má(f|vi)ni(gh|pe)bus(ixhg|/////cl|/hih|//to) i(gf|/cl)ni(g|vi)mi(h!iwj|viqlhi)có(ji|/cl-|jvIH|//ci-|ij|peShh)rum(i|ta)
+me(i!jwkJIH|qlhippt1sut3|iwjIH|ql-hgsu2)ó(g!hwihi|ql!poppt1)rum.(hg|/cl-) (::)
+
+<sp>V/</sp>.
+Mi(ji|/cl)sit(jkj|//tohh|/iji|//to|/hho1!g|pr) De(hi|pe)us(i|vi)
+mi(i|vi)se(i|vi)ri(ih|/cl)cór(jk~|pe~hh)di(j|tahg)am(j|tahg) su(jk|pehi)am(j|tahg) (`)
+et(j|ta) ve(ji|/cl)ri(ih|/cl)tá(ij|pe)tem(hi|pe) su(g!hwih|ql!clppt1)am:(hg|/cl) (;)
+á(g|vi)ni(fg|pe)mam(g|ta) me(gh|pe)am(g|ta) e(g|ta)rí(gh|pe)pu(g|ta)it(g|ta)
+de(g|ta) mé(gh|pe)di(g|ta)o(g|ta) ca(g|ta)tu(g|ta)ló(ixhiHG|////pe-su2|hih|//to)rum(ghf~|pe>)
+le(gh|peS)ó(iyh!iwji|////ql!clppt1|/jkJIH|///toS2hisu2)num.(hiHG|pe-1su2|hg|/cl-) (::)
+
+<v>\greheightstar</v>() I(fh!iwj|````qlhjppt2|jok|///pq-hh)pse.(g|ta) (::)
+
+Gló(j)ri(ji)a(jkj|//tohi|/iji|//tohh|/hhO1g|pr) Pa(ih)tri,(ij)
+et(hi) Fí(g)li(g!hwih|ql!cl-ppt1)o,(hg|/cl-) (;)
+et(g) Spi(g)rí(hiHGhih|//pe-su2/to)tu(ghf|//to)i(gh|peS)
+San(h!iwji|ql!clppt1|/jkjIH|////toS2hisu2)cto.(hiHGhg|pe-1su2cl-) (::)
+
+<v>\greheightstar</v>() I(fh!iwj|````qlhjppt2|jok|///pq-hh)pse.(g|ta) (::)

--- a/Conventus/inbox/resp-praeparatecordavestra-sinedox.gabc
+++ b/Conventus/inbox/resp-praeparatecordavestra-sinedox.gabc
@@ -1,0 +1,22 @@
+name:Praeparate corda vestra;
+office-part:Responsorium;
+mode:3;
+source:http://gregofacsimil.free.fr/01-Restitution/Repons/Repons-en-pdf/75-De-Libro-Regum/10-Praeparate-corda-vestra.pdf;
+transcriber:Marek Klein;
+commentary:1 Sam 7,3; H397;
+cantusindex:007425;
+nabc-lines:1;
+nabc-source:https://www.e-codices.unifr.ch/fr/csg/0391/203;
+%%
+(c4)Præ(c|gr)pa(d|vi)rá(ixfeh|//////po-1|iv|vihj)te(h|vi) (`)
+cor(h<|pe~)da(h|ta) ve(h|vi)stra(gh!iwj|``qlhhppt2) Dó(jvIH|//ci-|ih|/cl-)mi(g!hwjIHi|ql-ppt1su2/vi)no,(ih|/cl-) (;)
+et(g|ta) ser(hj~|pe~)ví(j|vi)te(ij|pe) il(hggof~|/clor)li(gh|pe) so(g|ta-|/hfg|//po)li,(fg|pe-1|/ffo1d|/pr) (;)
+<v>\greheightstar</v>()
+Et(fd~|cl~) li(g|vi)be(h!iwj|vi-qlhi)rá(jvIH|//ci-)bit(gf|/cl-|!gwhgh|ql!po) vos(g|ta) (,)
+de(h|vi) má(gh|peS)ni(fe|cllsc2)bus(d|ta) i(dc|cllsc2)ni(f|vi)mi(gh|pe)có(ixhiHGFgh|////toSsu2peS)rum(g|ta)
+ve(gh!iwjIH|``ql-hhppt2sut2|ig|/cl|ixhwiHG|////qi-sut2)stró(egffs|//tost)rum.(fe|/cl-) (::)
+
+<sp>V/</sp>.
+Au(i|vi)fér(ikjjs|//tohhsthj)te(h!iwji|ql!poppt1|hho1g|/pr) de(h|vi)os(ig|/cl) a(h|vi)li(j|vi)é(ikjjs|/trhh)nos(ji|/cl-) (;) de(i|vi) mé(ikj|//tohh|jvIHiwji|//ci-hgql!cl)di(hg|/cl)o(gh!iwj|``qlhhppt2) ve(jiio1h|//clhh!pihh|ivHGh|//ci-hh/vi)stri.(hg|/cl-) (::)
+
+<v>\greheightstar</v>() Et.(fd~|/cl~) (::)


### PR DESCRIPTION
Responsoria su CROCHU verzie;
Antifony su z "edicie Fontfroide";
Invitatorium som mal uz skor prepisane z Liber Hymnarius 1983 - antifony treba prisposobit...
Hymnus je tiez verzia z Liber Hymnarius - nasiel som na Gregobase.